### PR TITLE
Fix false-positive win function detection (_Unwind symbols)

### DIFF
--- a/commons/sensitive_functions.py
+++ b/commons/sensitive_functions.py
@@ -2,6 +2,8 @@
 
 import logging
 import typing
+import re
+
 from dataclasses import dataclass
 
 from pwn import ELF
@@ -32,4 +34,7 @@ def get_sensitive_functions_names(
 
 
 def __is_sensitive(function_name: str) -> bool:
-    return any([string in function_name for string in SENSITIVE_STRINGS])
+    return any(
+        re.search(rf"(^|_){kw}($|_)", function_name)
+        for kw in SENSITIVE_STRINGS
+    )


### PR DESCRIPTION
Previously, simple substring matching caused standard stack unwinding functions to be falsely flagged as sensitive because they contain the substring "win".
Enforce underscore and boundary-based regex matching so only true standalone ret2win-style functions are detected.